### PR TITLE
Enhancement/28 선택된 마커만 띄우기, 동선 그리기

### DIFF
--- a/src/main/resources/static/style/mapMarker.css
+++ b/src/main/resources/static/style/mapMarker.css
@@ -121,7 +121,7 @@ html > body {
     width: 36px;
     height: 37px;
     margin: 10px 0 0 10px;
-    background: url(https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png) no-repeat;
+   background: url(https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png) no-repeat;
 }
 
 #placesList .item .marker_1 {

--- a/src/main/resources/templates/post/post_create.html
+++ b/src/main/resources/templates/post/post_create.html
@@ -317,6 +317,10 @@
         var isFirst = true;
 
 
+        var clickLine = null;
+
+        var isFirst = true;
+
         // 마커를 생성하고 지도 위에 마커를 표시하는 함수입니다
         function addSelectedMarker(selectedData) {
 
@@ -410,10 +414,18 @@
         while (el.hasChildNodes()) {
             el.removeChild (el.lastChild);
         }
+
     }
-    // 지도에 클릭 이벤트를 등록합니다
-    // 지도를 클릭하면 선 그리기가 시작됩니다 그려진 선이 있으면 지우고 다시 그립니다
-    kakao.maps.event.addListener(map, 'click', function(mouseEvent) {
+        // 지도에 클릭 이벤트를 등록합니다
+        // 지도를 클릭하면 선 그리기가 시작됩니다 그려진 선이 있으면 지우고 다시 그립니다
+        kakao.maps.event.addListener(map, 'click', function(mouseEvent) {
+
+            // 마우스로 클릭한 위치입니다
+            var clickPosition = mouseEvent.latLng;
+            console.log(clickPosition)
+        });
+    </script>
+
 
         // 마우스로 클릭한 위치입니다
         var clickPosition = mouseEvent.latLng;

--- a/src/main/resources/templates/post/post_create.html
+++ b/src/main/resources/templates/post/post_create.html
@@ -71,13 +71,37 @@
             </div>
         </div>
     </div>
+
 </div>
 
-<script>
-    var selectedData = {};
+    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=1110141fa1f2c03d5f7f689ec5fb2e71&libraries=services"></script>
+    <script>
 
-    function addPlaceInput() {
-        console.log(selectedData)
+        var mapContainer = document.getElementById('map'), // 지도를 표시할 div
+            mapOption = {
+                center: new kakao.maps.LatLng(37.566826, 126.9786567), // 지도의 중심좌표
+                level: 3 // 지도의 확대 레벨
+            };
+
+        // 지도를 생성합니다
+        var map = new kakao.maps.Map(mapContainer, mapOption);
+
+        //선택된마커를 담을 배열입니다.
+        var selectedMarkers =[];
+
+        var selectedData = {}
+
+        function addPlaceInput() {
+
+            console.log(selectedData)
+
+            if (selectedData) {
+                addSelectedMarker(selectedData)
+            }
+
+            var placeList = document.getElementById("placeList");
+            var index = placeList.children.length;
+            var newPlaceInput = document.createElement("div");
 
         var index = document.querySelectorAll("#placeList > div").length;
         var newPlaceInput = `<input type="hidden" name="postPlaces[${index}].id" value="${selectedData.id}"/>
@@ -143,6 +167,7 @@
             return false;
         }
 
+
         // 장소검색 객체를 통해 키워드로 장소검색을 요청합니다
         ps.keywordSearch( keyword, placesSearchCB);
     }
@@ -170,137 +195,215 @@
 
         }
     }
+        // 검색 결과 목록과 마커를 표출하는 함수입니다
+        function displayPlaces(places) {
 
-    // 검색 결과 목록과 마커를 표출하는 함수입니다
-    function displayPlaces(places) {
+            var listEl = document.getElementById('placesList'),
+                menuEl = document.getElementById('menu_wrap'),
+                fragment = document.createDocumentFragment(),
+                bounds = new kakao.maps.LatLngBounds(),
+                listStr = '';
 
-        var listEl = document.getElementById('placesList'),
-            menuEl = document.getElementById('menu_wrap'),
-            fragment = document.createDocumentFragment(),
-            bounds = new kakao.maps.LatLngBounds(),
-            listStr = '';
+            // 검색 결과 목록에 추가된 항목들을 제거합니다
+            removeAllChildNods(listEl);
 
-        // 검색 결과 목록에 추가된 항목들을 제거합니다
-        removeAllChildNods(listEl);
+            for ( var i=0; i<places.length; i++ ) {
 
-        // 지도에 표시되고 있는 마커를 제거합니다
-        removeMarker();
+                // 마커를 생성하고 지도에 표시합니다
+                var placePosition = new kakao.maps.LatLng(places[i].y, places[i].x),
+                    marker = addMarker(placePosition),
+                    itemEl = getListItem(i, places[i]); // 검색 결과 항목 Element를 생성합니다
 
-        for ( var i=0; i<places.length; i++ ) {
+                // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
+                // LatLngBounds 객체에 좌표를 추가합니다
+                bounds.extend(placePosition);
 
-            // 마커를 생성하고 지도에 표시합니다
-            var placePosition = new kakao.maps.LatLng(places[i].y, places[i].x),
-                marker = addMarker(placePosition, i),
-                itemEl = getListItem(i, places[i]); // 검색 결과 항목 Element를 생성합니다
-
-            // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
-            // LatLngBounds 객체에 좌표를 추가합니다
-            bounds.extend(placePosition);
-
-            // 마커와 검색결과 항목에 mouseover 했을때
-            // 해당 장소에 인포윈도우에 장소명을 표시합니다
-            // mouseout 했을 때는 인포윈도우를 닫습니다
-            (function(marker, title) {
-                kakao.maps.event.addListener(marker, 'mouseover', function() {
-                    displayInfowindow(marker, title);
-                });
-
-                kakao.maps.event.addListener(marker, 'mouseout', function() {
-                    infowindow.close();
-                });
-                //리스트 마우스오버 이벤트
-                itemEl.onmouseover =  function () {
-                    displayInfowindow(marker, title);
-                    //marker.setMap(map);
-                };
-
-                itemEl.onmouseout =  function () {
-                    infowindow.close();
-                    //marker.setMap(null);
-                };
-            })(marker, places[i].place_name);
-
-            fragment.appendChild(itemEl);
-
-            //리스트에 클릭이벤트 주기
-            (function (marker, placeData){
-                itemEl.onclick = function () {
-                    //console.log("클릭 이벤트 발생!!!")
-                    markers.forEach(marker=>{
-                        marker.setMap(null);
-                        console.log("다른 마커들삭제")
+                // 마커와 검색결과 항목에 mouseover 했을때
+                // 해당 장소에 인포윈도우에 장소명을 표시합니다
+                // mouseout 했을 때는 인포윈도우를 닫습니다
+                (function(marker, title) {
+                    kakao.maps.event.addListener(marker, 'mouseover', function() {
+                        displayInfowindow(marker, title);
                     });
-                    console.log("마커보이기")
-                    marker.setMap(map);
-                    console.log(placeData)
-                    selectedData = placeData;
-                    addPlaceInput();
+
+                    kakao.maps.event.addListener(marker, 'mouseout', function() {
+                        infowindow.close();
+                    });
+                    //리스트 마우스오버 이벤트
+                    itemEl.onmouseover =  function () {
+                        displayInfowindow(marker, title);
+                    };
+
+                    itemEl.onmouseout =  function () {
+                        infowindow.close();
+                    };
+                })(marker, places[i].place_name);
+
+                fragment.appendChild(itemEl);
+
+                //리스트에 클릭이벤트 주기
+                (function (placeData){
+                    itemEl.onclick = function (e) {
+
+                        console.log(e)
+
+                        //console.log("클릭 이벤트 발생!!!")
+                        // markers.forEach(marker=>{
+                        //     marker.setMap(null);
+                        //     console.log("다른 마커들삭제")
+                        // });
+
+                        selectedData = placeData;
+
+                        console.log("마커보이기")
+
+                        addPlaceInput();
+
+                        //slectedData를 selectedMarker에 넘기기
+
+                        console.log("마커정보 selectedMarker에 넘기기")
+                    }
+
+                })(places[i]);
+            }
+
+
+            // 검색결과 항목들을 검색결과 목록 Element에 추가합니다
+            listEl.appendChild(fragment);
+            menuEl.scrollTop = 0;
+
+            // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+            map.setBounds(bounds);
+        }
+
+        // 검색결과 항목을 Element로 반환하는 함수입니다
+        function getListItem(index, places) {
+
+            var el = document.createElement('li'),
+                itemStr = '<span class="markerbg marker_' + (index+1) + '"></span>' +
+                    '<div class="info">' +
+                    '   <h5>' + places.place_name + '</h5>';
+
+            if (places.road_address_name) {
+                itemStr += '    <span>' + places.road_address_name + '</span>' +
+                    '   <span class="jibun gray">' +  places.address_name  + '</span>';
+            } else {
+                itemStr += '    <span>' +  places.address_name  + '</span>';
+            }
+
+            itemStr += '  <span class="tel">' + places.phone  + '</span>' +
+                '</div>';
+
+            el.innerHTML = itemStr;
+            el.className = 'item';
+
+            return el;
+        }
+
+        // 마커를 생성하고 지도 위에 마커를 표시하는 함수입니다
+        function addMarker(position) {
+            var imageSrc = "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png", // 마커 이미지 url, 스프라이트 이미지를 씁니다
+            imageSize = new kakao.maps.Size(24, 35),
+            markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize),
+                marker = new kakao.maps.Marker({
+                    position: position, // 마커의 위치
+                    image: markerImage
+                });
+
+            return marker;
+        }
+        var clickLine = null;
+
+        var isFirst = true;
+
+
+        // 마커를 생성하고 지도 위에 마커를 표시하는 함수입니다
+        function addSelectedMarker(selectedData) {
+
+            var imageSrc = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png', // 마커 이미지 url, 스프라이트 이미지를 씁니다
+                imageSize = new kakao.maps.Size(36, 37),  // 마커 이미지의 크기
+                imgOptions =  {
+                    spriteSize : new kakao.maps.Size(36, 691), // 스프라이트 이미지의 크기
+                    spriteOrigin : new kakao.maps.Point(0, (selectedMarkers.length*46)+10), // 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
+                    offset: new kakao.maps.Point(13, 37) // 마커 좌표에 일치시킬 이미지 내에서의 좌표
+                },
+                markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imgOptions),
+                marker = new kakao.maps.Marker({
+                    position: new kakao.maps.LatLng(selectedData.y, selectedData.x), // 마커의 위치
+                    image: markerImage
+                });
+
+            marker.setMap(map)
+
+            var clickPosition = new kakao.maps.LatLng(selectedData.y, selectedData.x)
+
+            if (isFirst) {
+                isFirst = false;
+                // 클릭한 위치를 기준으로 선을 생성하고 지도위에 표시합니다
+                clickLine = new kakao.maps.Polyline({
+                    map: map, // 선을 표시할 지도입니다
+                    path: [clickPosition], // 선을 구성하는 좌표 배열입니다 클릭한 위치를 넣어줍니다
+                    strokeWeight: 5, // 선의 두께입니다
+                    strokeColor: '#db4040', // 선의 색깔입니다
+                    strokeOpacity: 1, // 선의 불투명도입니다 0에서 1 사이값이며 0에 가까울수록 투명합니다
+                    strokeStyle: 'solid' // 선의 스타일입니다
+                });
+            } else {
+                // 그려지고 있는 선의 좌표 배열을 얻어옵니다
+                var path = clickLine.getPath();
+
+                // 좌표 배열에 클릭한 위치를 추가합니다
+                path.push(clickPosition);
+
+                // 다시 선에 좌표 배열을 설정하여 클릭 위치까지 선을 그리도록 설정합니다
+                clickLine.setPath(path);
+            }
+
+            selectedMarkers.push(marker);  // 배열에 생성된 마커를 추가합니다
+
+            return marker;
+
+
+        }
+        // 검색결과 목록 하단에 페이지번호를 표시는 함수입니다
+        function displayPagination(pagination) {
+            var paginationEl = document.getElementById('pagination'),
+                fragment = document.createDocumentFragment(),
+                i;
+
+            // 기존에 추가된 페이지번호를 삭제합니다
+            while (paginationEl.hasChildNodes()) {
+                paginationEl.removeChild (paginationEl.lastChild);
+            }
+
+            for (i=1; i<=pagination.last; i++) {
+                var el = document.createElement('a');
+                el.href = "#";
+                el.innerHTML = i;
+
+                if (i===pagination.current) {
+                    el.className = 'on';
+                } else {
+                    el.onclick = (function(i) {
+                        return function() {
+                            pagination.gotoPage(i);
+                        }
+                    })(i);
                 }
 
-            })(marker, places[i]);
+                fragment.appendChild(el);
+            }
+            paginationEl.appendChild(fragment);
         }
 
+        // 검색결과 목록 또는 마커를 클릭했을 때 호출되는 함수입니다
+        // 인포윈도우에 장소명을 표시합니다
+        function displayInfowindow(marker, title) {
+            var content = '<div style="padding:5px;z-index:1;">' + title + '</div>';
 
-        // 검색결과 항목들을 검색결과 목록 Element에 추가합니다
-        listEl.appendChild(fragment);
-        menuEl.scrollTop = 0;
-
-        // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
-        map.setBounds(bounds);
-    }
-
-    // 검색결과 항목을 Element로 반환하는 함수입니다
-    function getListItem(index, places) {
-
-        var el = document.createElement('li'),
-            itemStr = '<span class="markerbg marker_' + (index+1) + '"></span>' +
-                '<div class="info">' +
-                '   <h5>' + places.place_name + '</h5>';
-
-        if (places.road_address_name) {
-            itemStr += '    <span>' + places.road_address_name + '</span>' +
-                '   <span class="jibun gray">' +  places.address_name  + '</span>';
-        } else {
-            itemStr += '    <span>' +  places.address_name  + '</span>';
+            infowindow.setContent(content);
+            infowindow.open(map, marker);
         }
-
-        itemStr += '  <span class="tel">' + places.phone  + '</span>' +
-            '</div>';
-
-        el.innerHTML = itemStr;
-        el.className = 'item';
-
-        return el;
-    }
-
-    // 마커를 생성하고 지도 위에 마커를 표시하는 함수입니다
-    function addMarker(position, idx, title) {
-        var imageSrc = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png', // 마커 이미지 url, 스프라이트 이미지를 씁니다
-            imageSize = new kakao.maps.Size(36, 37),  // 마커 이미지의 크기
-            imgOptions =  {
-                spriteSize : new kakao.maps.Size(36, 691), // 스프라이트 이미지의 크기
-                spriteOrigin : new kakao.maps.Point(0, (idx*46)+10), // 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
-                offset: new kakao.maps.Point(13, 37) // 마커 좌표에 일치시킬 이미지 내에서의 좌표
-            },
-            markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imgOptions),
-            marker = new kakao.maps.Marker({
-                position: position, // 마커의 위치
-                image: markerImage
-            });
-
-        marker.setMap(map); // 지도 위에 마커를 표출합니다
-        markers.push(marker);  // 배열에 생성된 마커를 추가합니다
-
-        return marker;
-    }
-
-    // 지도 위에 표시되고 있는 마커를 모두 제거합니다
-    function removeMarker() {
-        for ( var i = 0; i < markers.length; i++ ) {
-            markers[i].setMap(null);
-        }
-        markers = [];
-    }
 
     // 검색결과 목록의 자식 Element를 제거하는 함수입니다
     function removeAllChildNods(el) {
@@ -308,6 +411,14 @@
             el.removeChild (el.lastChild);
         }
     }
+    // 지도에 클릭 이벤트를 등록합니다
+    // 지도를 클릭하면 선 그리기가 시작됩니다 그려진 선이 있으면 지우고 다시 그립니다
+    kakao.maps.event.addListener(map, 'click', function(mouseEvent) {
+
+        // 마우스로 클릭한 위치입니다
+        var clickPosition = mouseEvent.latLng;
+        console.log(clickPosition)
+    });
 
     // 폼 전송 함수
     function submitForm() {


### PR DESCRIPTION
## 개요:
Enhancement/28 선택된 마커만 띄우기, 동선 그리기

## 화면
![image](https://github.com/Tour-de-Monde/Tour-de-Monde/assets/79620776/266ad092-1f71-4991-8cd6-b073bb60d55f)


## 개선할점 
1. flex로 html 구조 수평으로 바꿔서 지도 위로 올리기.
2. 마커이미지 빨간색 number로 바꾸기 
### 마커 이미지 후보
![image](https://github.com/Tour-de-Monde/Tour-de-Monde/assets/79620776/78df7151-57bf-469c-8125-ed4b3eb675a8)
![image](https://github.com/Tour-de-Monde/Tour-de-Monde/assets/79620776/d5edfac1-a932-4cac-9746-348b58270116)

참고문서:
[여러개 마커 제어하기](https://apis.map.kakao.com/web/sample/multipleMarkerControl/)

[선의 거리 계산하기
](https://apis.map.kakao.com/web/sample/calculatePolylineDistance/)
